### PR TITLE
Update OWASP backronym: Web -> Worldwide

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ pitch: A very brief, one-line description of your project
 OWASP Top Ten Card Game
 Background and Rules
 
-The OWASP Top 10 Card Game is an educational card game designed to help novice students learn about web application security, specifically by using the OWASP Top 10 — a widely recognized list of the top ten most critical web application security risks published by the Open Web Application Security Project (OWASP).
+The OWASP Top 10 Card Game is an educational card game designed to help novice students learn about web application security, specifically by using the OWASP Top 10 — a widely recognized list of the top ten most critical web application security risks published by the Open Worldwide Application Security Project (OWASP).
 
 The game is easy to learn and designed to introduce risk concepts of the OWASP Top Ten and the best practices control concepts of the OWASP Top Ten Proactive Controls at a novice level in an environment that reflects a sense of realism and excitement. 
 


### PR DESCRIPTION

This PR has been generated by [Arkadii Yakovets](https://nest.owasp.org/members/arkid15r) based on the OWASP Board of Directors February 2023 [motion](https://board.owasp.org/meetings-historical/2023/202302.15.html) to officially change the backronym OWASP (sponsored by [Mark Curphey](https://nest.owasp.org/members/curphey) and [Avi Douglen](https://nest.owasp.org/members/avidouglen)).

>Background: Motion: "Resolved that the Foundation will change **all current and future references** of the 'Open Web Application Security Project' to the 'Open Worldwide Application Security Project'".

The purpose of this PR is to update all references to OWASP to reflect the Board approved change of the organization's name from Open **Web** Application Security Project to Open **Worldwide** Application Security Project. This ensures consistency across documentation, metadata, and project materials in alignment with the Board's decision.

For any questions or clarifications you can reach out via:

- OWASP Slack: [Arkadii Yakovets](https://owasp.slack.com/team/U060W3NKLTF)
- LinkedIn: [in/arkid15r](https://www.linkedin.com/in/arkid15r)